### PR TITLE
Implement Find node RPC

### DIFF
--- a/pkg/kademlia/contact.go
+++ b/pkg/kademlia/contact.go
@@ -18,7 +18,7 @@ func NewContact(id *KademliaID, address string) Contact {
 	return Contact{id, address, nil}
 }
 
-// CalcDistance calculates the distance to the target and 
+// CalcDistance calculates the distance to the target and
 // fills the contacts distance field
 func (contact *Contact) CalcDistance(target *KademliaID) {
 	contact.distance = contact.ID.CalcDistance(target)
@@ -66,8 +66,25 @@ func (candidates *ContactCandidates) Swap(i, j int) {
 	candidates.contacts[i], candidates.contacts[j] = candidates.contacts[j], candidates.contacts[i]
 }
 
-// Less returns true if the Contact at index i is smaller than 
+// Less returns true if the Contact at index i is smaller than
 // the Contact at index j
 func (candidates *ContactCandidates) Less(i, j int) bool {
 	return candidates.contacts[i].Less(&candidates.contacts[j])
+}
+
+// Takes the shortlist and removes all the duplicate contacts
+func (candidates *ContactCandidates) RemoveDuplicates() {
+	newContactList := make([]Contact, 0)
+	for _, contact := range candidates.contacts {
+		duplicateExist := false
+		for _, notDuplicateContact := range newContactList {
+			if contact.ID == notDuplicateContact.ID {
+				duplicateExist = true
+			}
+		}
+		if !duplicateExist {
+			newContactList = append(newContactList, contact)
+		}
+	}
+	candidates.contacts = newContactList
 }

--- a/pkg/kademlia/kademlia.go
+++ b/pkg/kademlia/kademlia.go
@@ -39,29 +39,20 @@ func (kademlia *Kademlia) LookupContact(target *Contact) *ContactCandidates {
 	shortlist.contacts = closestNodes
 	//Initiate channel where shortlists from the goroutines will be written to
 	shortlistCh := make(chan []Contact)
+	//Channel for writing inactive nodes to
 	hasNotAnsweredCh := make(chan Contact)
 
 	hasBeenContactedList := ContactCandidates{}
 	hasNotAnsweredList := ContactCandidates{}
 
 	closerNodeHasBeenFound := true
+	go manageInactiveNodes(hasNotAnsweredCh, &hasNotAnsweredList)
 	for closerNodeHasBeenFound {
 		//Send find node RPC to alpha number of contacts in the shortlist
 		for i := 0; i < kademlia.alpha; i++ {
 			go SendFindNodeRPC(&shortlist.contacts[i], target, kademlia.network, shortlistCh, hasNotAnsweredCh)
 		}
-		//Add contacted nodes to the list
-		hasBeenContactedList.Append(shortlist.GetContacts(kademlia.alpha))
-		//Retrieve all contacts that failed to answered
-		inactiveNodes := retrieveInactiveNodes(kademlia.alpha, hasNotAnsweredCh)
-		hasNotAnsweredList.Append(inactiveNodes)
-		//Retrieve all shortlists from the contacted nodes
-		newShortlists := retrieveShortlists(kademlia.alpha, shortlistCh)
-		shortlist.Append(newShortlists)
-		//Sort the new shortlist and remove any duplicates
-		shortlist.Sort()
-		shortlist.RemoveDuplicates()
-		shortlist.contacts = shortlist.GetContacts(bucketSize)
+		manageShortlist(kademlia.alpha, &shortlist, shortlistCh)
 		//Check end condition
 		if shortlist.contacts[0].Less(closestContact) {
 			closestContact = &shortlist.contacts[0]
@@ -75,28 +66,32 @@ func (kademlia *Kademlia) LookupContact(target *Contact) *ContactCandidates {
 			for _, nodeToContact := range nodesToContact.GetContacts(bucketSize) {
 				go SendFindNodeRPC(&nodeToContact, target, kademlia.network, shortlistCh, hasNotAnsweredCh)
 			}
-			//Retrieve shortlists from contacted nodes
-			newShortlists := retrieveShortlists(kademlia.alpha, shortlistCh)
-			shortlist.Append(newShortlists)
-			shortlist.Sort()
-			shortlist.RemoveDuplicates()
+			manageShortlist(kademlia.alpha, &shortlist, shortlistCh)
 			//Remove all inactive nodes from the shortlist
 			shortlist.contacts = removeInactiveNodes(shortlist, hasNotAnsweredList)
-
-			shortlist.contacts = shortlist.GetContacts(bucketSize)
-			//Stop FIND_NODE_RPC
 		}
 	}
 	return &shortlist
 }
 
-func retrieveShortlists(alpha int, shortlistCh chan []Contact) []Contact {
-	shortlists := make([]Contact, 0)
+//Sends a find node RPC to the contact which will send back the k closest nodes. These contacts will be written to the
+//channel to be retireved
+func SendFindNodeRPC(contact *Contact, target *Contact, network *Network, shortlistChannel chan []Contact, hasNotAnsweredChannel chan Contact) {
+	closestNodes, didNotAnswer := network.SendFindContactMessage(contact, target, hasNotAnsweredChannel)
+	shortlistChannel <- closestNodes
+	if didNotAnswer {
+		hasNotAnsweredChannel <- *contact
+	}
+}
+
+func manageShortlist(alpha int, shortlist *ContactCandidates, shortlistCh chan []Contact) {
 	for i := 0; i < alpha; i++ {
 		newShortList := <-shortlistCh
-		shortlists = append(shortlists, newShortList...)
+		shortlist.Append(newShortList)
+		shortlist.Sort()
+		shortlist.RemoveDuplicates()
+		shortlist.contacts = shortlist.GetContacts(bucketSize)
 	}
-	return shortlists
 }
 
 //Calculates the distances from the contacts to the target contact and returns the contact with the shortest distance
@@ -115,22 +110,6 @@ func findClosestContact(contacts []Contact, target *Contact) *Contact {
 	return closestNode
 }
 
-//Sends a find node RPC to the contact which will send back the k closest nodes. These contacts will be written to the
-//channel to be retireved
-func SendFindNodeRPC(contact *Contact, target *Contact, network *Network, shortlistChannel chan []Contact, hasNotAnsweredChannel chan Contact) {
-	closestNodes := network.SendFindContactMessage(contact, target, hasNotAnsweredChannel)
-	shortlistChannel <- closestNodes
-}
-
-func retrieveInactiveNodes(alpha int, hasNotAnsweredCh chan Contact) []Contact {
-	inactiveNodes := make([]Contact, bucketSize)
-	for i := 0; i < alpha; i++ {
-		inactiveNode := <-hasNotAnsweredCh
-		inactiveNodes = append(inactiveNodes, inactiveNode)
-	}
-	return inactiveNodes
-}
-
 func findNotContactedNodes(shortlist *ContactCandidates, contactedNodes *ContactCandidates) ContactCandidates {
 	hasNotBeenContactedList := make([]Contact, 0)
 	for _, contact := range shortlist.contacts {
@@ -145,6 +124,13 @@ func findNotContactedNodes(shortlist *ContactCandidates, contactedNodes *Contact
 		}
 	}
 	return ContactCandidates{hasNotBeenContactedList}
+}
+
+func manageInactiveNodes(hasNotAnsweredCh chan Contact, hasNotAnsweredList *ContactCandidates) {
+	for {
+		inactiveNode := <-hasNotAnsweredCh
+		hasNotAnsweredList.Append([]Contact{inactiveNode})
+	}
 }
 
 func removeInactiveNodes(shortlist ContactCandidates, inactiveNodes ContactCandidates) []Contact {

--- a/pkg/kademlia/kademlia.go
+++ b/pkg/kademlia/kademlia.go
@@ -69,14 +69,15 @@ func (kademlia *Kademlia) LookupContact(target *Contact) {
 			closestContact = &shortlist.contacts[0]
 		} else {
 			closerNodeHasBeenFound = false
-			//Send a RPC to each of the k closest nodes that has not already been queried
+			//Find closest nodes that have not yet been contacted
 			nodesToContact := findNotContactedNodes(&shortlist, &hasBeenContactedList)
 			nodesToContact.Sort()
 			nodesToContact.RemoveDuplicates()
+			//Send a RPC to each of the k closest nodes that has not already been contacted
 			for _, nodeToContact := range nodesToContact.GetContacts(bucketSize) {
 				go SendFindNodeRPC(&nodeToContact, target, kademlia.network, shortlistCh, hasNotAnsweredCh)
 			}
-			//Retrieve shortlists
+			//Retrieve shortlists from contacted nodes
 			for i := 0; i < bucketSize; i++ {
 				newShortList := <-shortlistCh
 				shortlist.Append(newShortList)
@@ -84,6 +85,7 @@ func (kademlia *Kademlia) LookupContact(target *Contact) {
 			shortlist.Sort()
 			shortlist.RemoveDuplicates()
 			//Remove inactive nodes
+
 			shortlist.contacts = shortlist.GetContacts(bucketSize)
 			//Stop FIND_NODE_RPC
 		}

--- a/pkg/kademlia/kademlia_test.go
+++ b/pkg/kademlia/kademlia_test.go
@@ -1,0 +1,25 @@
+package kademlia
+
+import "testing"
+
+func TestFindClosestContact(t *testing.T) {
+	//0000000000000000000000000000000000000002
+	//0000000000000000000000000000000000000003 closest
+	//0000000000000000000000000000000000000004
+
+	//0000000000000000000000000000000000000001 TARGET
+	kademliaID1 := NewKademliaID("0000000000000000000000000000000000000001")
+	kademliaID2 := NewKademliaID("0000000000000000000000000000000000000002")
+	kademliaID3 := NewKademliaID("0000000000000000000000000000000000000003")
+	kademliaID4 := NewKademliaID("0000000000000000000000000000000000000004")
+	node1 := NewContact(kademliaID1, "172.16.0.2:8000")
+	node2 := NewContact(kademliaID2, "172.16.0.3:8000")
+	node3 := NewContact(kademliaID3, "172.16.0.4:8000")
+	node4 := NewContact(kademliaID4, "172.16.0.5:8000")
+	contacts := []Contact{node2, node3, node4}
+
+	closestContact := findClosestContact(contacts, &node1)
+	if closestContact.ID != node3.ID {
+		t.Errorf("Contact ID was incorrect, got %s, want: %s", closestContact.ID.String(), node3.ID.String())
+	}
+}

--- a/pkg/kademlia/kademlia_test.go
+++ b/pkg/kademlia/kademlia_test.go
@@ -23,3 +23,15 @@ func TestFindClosestContact(t *testing.T) {
 		t.Errorf("Contact ID was incorrect, got %s, want: %s", closestContact.ID.String(), node3.ID.String())
 	}
 }
+
+func TestSendFindNodeRPC(t *testing.T) {
+	kademliaID1 := NewKademliaID("0000000000000000000000000000000000000001")
+	kademliaID2 := NewKademliaID("0000000000000000000000000000000000000002")
+	node1 := NewContact(kademliaID1, "172.16.0.2:8000")
+	node2 := NewContact(kademliaID2, "172.16.0.3:8000")
+	network := Network{}
+	shortlistChan := make(chan []Contact)
+	hasNotAnsweredChan := make(chan Contact)
+	go SendFindNodeRPC(&node1, &node2, &network, shortlistChan, hasNotAnsweredChan)
+	//TODO: Read from channels
+}

--- a/pkg/kademlia/network.go
+++ b/pkg/kademlia/network.go
@@ -58,8 +58,62 @@ func sendResponse(conn *net.UDPConn, addr *net.UDPAddr) {
 	}
 }
 
-func (network *Network) SendFindContactMessage(contact *Contact) []Contact {
-	// TODO
+func (network *Network) SendFindContactMessage(contact *Contact, target *Contact, hasNotAnsweredChannel chan Contact) []Contact {
+	conn, err := net.Dial("tcp", contact.Address)
+	if err != nil {
+		hasNotAnsweredChannel <- *contact
+		return []Contact{}
+	}
+	reader := bufio.NewReader(conn)
+	targetAsString := target.String()
+	fmt.Fprintf(conn, "FIND_NODE_RPC;"+targetAsString+"\n")
+	shortListString, err := reader.ReadString('\n')
+	shortList := preprocessShortlist(shortListString)
+	if err != nil {
+		hasNotAnsweredChannel <- *contact
+		return []Contact{}
+	}
+	return shortList
+}
+
+func preprocessShortlist(shortlistString string) []Contact {
+	var contactString string
+	shortlist := make([]Contact, 0)
+	for _, letter := range shortlistString {
+		if string(letter) == ";" {
+			newContact := StringToContact(contactString)
+			shortlist = append(shortlist, newContact)
+			contactString = ""
+		} else {
+			contactString = contactString + string(letter)
+		}
+	}
+	return shortlist
+}
+
+func StringToContact(contactAsString string) Contact {
+	var address string
+	var id string
+	contactRune := []rune(contactAsString)
+	hasReadAddress := false
+	for i := 8; i < len(contactRune); i++ {
+		if string(contactRune[i]) == ")" {
+			break
+		}
+		if string(contactRune[i]) == "," {
+			hasReadAddress = true
+			i = i + 2
+		}
+		if hasReadAddress {
+			id = id + string(contactRune[i])
+		} else {
+			address = address + string(contactRune[i])
+		}
+	}
+	newKademliaID := NewKademliaID(id)
+	newContact := NewContact(newKademliaID, address)
+	return newContact
+
 }
 
 func (network *Network) SendFindDataMessage(hash string) {

--- a/pkg/kademlia/network.go
+++ b/pkg/kademlia/network.go
@@ -58,13 +58,13 @@ func sendResponse(conn *net.UDPConn, addr *net.UDPAddr) {
 	}
 }
 
-func (network *Network) SendFindContactMessage(contact *Contact, target *Contact, hasNotAnsweredChannel chan Contact) []Contact {
+func (network *Network) SendFindContactMessage(contact *Contact, target *Contact, hasNotAnsweredChannel chan Contact) ([]Contact, bool) {
 	//Establish connection
 	conn, err := net.Dial("tcp", contact.Address)
 	//Send contact to channel to mark as inactive
 	if err != nil {
-		hasNotAnsweredChannel <- *contact
-		return []Contact{}
+		didNotAnswer := true
+		return []Contact{}, didNotAnswer
 	}
 	reader := bufio.NewReader(conn)
 	targetAsString := target.String()
@@ -73,11 +73,12 @@ func (network *Network) SendFindContactMessage(contact *Contact, target *Contact
 	//Wait for showrtlist as answer
 	shortListString, err := reader.ReadString('\n')
 	if err != nil {
-		hasNotAnsweredChannel <- *contact
-		return []Contact{}
+		didNotAnswer := true
+		return []Contact{}, didNotAnswer
 	}
 	shortList := preprocessShortlist(shortListString)
-	return shortList
+	didNotAnswer := false
+	return shortList, didNotAnswer
 }
 
 //When receiving a shortlist it will be a string with the structure that looks like this:


### PR DESCRIPTION
**Why this pull request is needed**
This pull request adds functionality to lookup a node in the network. It does this by finding the closest nodes to the target in its own buckets and then concurrently sending FIND_NODE_RPCs to those nodes, which in turn will send back their shortlists of closest nodes. This will repeat until no node is closer than the already seen closest one.

**Fixes**
#34
#17
#16
#13
#11
#9
#6
#4