### PR TITLE
Implementation for updating the k-buckets

### DIFF
--- a/pkg/kademlia/kademlia_test.go
+++ b/pkg/kademlia/kademlia_test.go
@@ -27,14 +27,19 @@ func TestFindClosestContact(t *testing.T) {
 }
 
 func TestSendFindNodeRPC(t *testing.T) {
-	kademliaID1 := NewKademliaID("0000000000000000000000000000000000000001")
-	kademliaID2 := NewKademliaID("0000000000000000000000000000000000000002")
-	node1 := NewContact(kademliaID1, "")
-	node2 := NewContact(kademliaID2, "")
 	network := Network{}
+
+	kademliaID1 := NewKademliaID("0000000000000000000000000000000000000001")
+	node1 := NewContact(kademliaID1, "")
+
+	kademliaInstance := Kademlia{3, NewRoutingTable(node1), &network}
+
+	kademliaID2 := NewKademliaID("0000000000000000000000000000000000000002")
+	node2 := NewContact(kademliaID2, "")
+
 	shortlistChan := make(chan []Contact)
 	hasNotAnsweredChan := make(chan Contact)
-	go SendFindNodeRPC(&node1, &node2, &network, shortlistChan, hasNotAnsweredChan)
+	go kademliaInstance.SendFindNodeRPC(&node1, &node2, &network, shortlistChan, hasNotAnsweredChan)
 	shortlis := <-shortlistChan
 	if len(shortlis) != 0 {
 		t.Errorf("Returned shortlist is not empty, got %d, want: %d", len(shortlis), 0)

--- a/pkg/kademlia/network.go
+++ b/pkg/kademlia/network.go
@@ -59,7 +59,6 @@ func sendResponse(conn *net.UDPConn, addr *net.UDPAddr) {
 	}
 }
 
-
 func (network *Network) SendFindContactMessage(contact *Contact, target *Contact, hasNotAnsweredChannel chan Contact) ([]Contact, bool) {
 	//Establish connection
 	conn, err := net.Dial("tcp", contact.Address)

--- a/pkg/kademlia/routingtable.go
+++ b/pkg/kademlia/routingtable.go
@@ -2,12 +2,12 @@ package kademlia
 
 const bucketSize = 20
 
-
 // RoutingTable definition
 // keeps a refrence contact of me and an array of buckets
 type RoutingTable struct {
-	me      Contact
-	buckets [IDLength * 8]*bucket
+	me               Contact
+	buckets          [IDLength * 8]*bucket
+	routingTableChan chan Contact
 }
 
 // NewRoutingTable returns a new instance of a RoutingTable
@@ -67,4 +67,12 @@ func (routingTable *RoutingTable) getBucketIndex(id *KademliaID) int {
 	}
 
 	return IDLength*8 - 1
+}
+
+//This goroutine needs to be started from main so that we can update the routing table whenever we get a message from a node
+func (routingTable *RoutingTable) UpdateRoutingTable() {
+	for {
+		newContact := <-routingTable.routingTableChan
+		routingTable.AddContact(newContact)
+	}
 }

--- a/pkg/kademlia/routingtable.go
+++ b/pkg/kademlia/routingtable.go
@@ -72,7 +72,10 @@ func (routingTable *RoutingTable) getBucketIndex(id *KademliaID) int {
 //This goroutine needs to be started from main so that we can update the routing table whenever we get a message from a node
 func (routingTable *RoutingTable) UpdateRoutingTable() {
 	for {
-		newContact := <-routingTable.routingTableChan
+		newContact, done := <-routingTable.routingTableChan
+		if done { //Quits goroutine if channel is closed
+			return
+		}
 		routingTable.AddContact(newContact)
 	}
 }

--- a/src/KademliaNode/main.go
+++ b/src/KademliaNode/main.go
@@ -7,7 +7,9 @@ import (
 
 func main() {
 	go cli.Cli()
-	net := &kademlia.Network{}
-	//kademlia.Listen("", 8000)
-	net.SendPingMessage()
+	kademliaID1 := kademlia.NewKademliaID("0000000000000000000000000000000000000001")
+	me := kademlia.NewContact(kademliaID1, "")
+	alpha := 3
+	kademliaInstance := kademlia.NewKademliaInstance(alpha, me)
+	kademliaInstance.Start()
 }


### PR DESCRIPTION
**Why is this PR needed**
This PR adds functionality for managing and adding contacts to the k-buckets in the kademlia package. The kademlia instance will continuously read from a channel and receive contacts that should be  added to the routing table and to add contacts you should write to the routing table channel

**Which issue(s) this PR fixes**‘
Fixes #32