### PR TITLE
Removed findClosestContact

### DIFF
--- a/pkg/kademlia/kademlia.go
+++ b/pkg/kademlia/kademlia.go
@@ -53,7 +53,9 @@ func (kademlia *Kademlia) LookupContact(target *Contact) *ContactCandidates {
 	//Find k closest nodes
 	closestNodes := kademlia.routingTable.FindClosestContacts(target.ID, kademlia.alpha)
 	//Initiate closestNode
-	closestContact := findClosestContact(closestNodes, target)
+	closestNodesToContactCandidates := ContactCandidates{closestNodes}
+	closestNodesToContactCandidates.Sort()
+	closestContact := &closestNodesToContactCandidates.contacts[0]
 	//Initiate shortlist
 	var shortlist ContactCandidates
 	shortlist.contacts = closestNodes
@@ -117,22 +119,6 @@ func manageShortlist(alpha int, shortlist *ContactCandidates, shortlistCh chan [
 		shortlist.contacts = shortlist.GetContacts(bucketSize)
 	}
 
-}
-
-//Calculates the distances from the contacts to the target contact and returns the contact with the shortest distance
-func findClosestContact(contacts []Contact, target *Contact) *Contact {
-	var closestNode *Contact = &contacts[0]
-	for i := 0; i < len(contacts); i++ {
-		contacts[i].CalcDistance(target.ID)
-	}
-	//Compare distances with the closestNode and update it accordingly
-	for j := 0; j < len(contacts); j++ {
-		if contacts[j].distance.Less(closestNode.distance) {
-			closestNode = &contacts[j]
-		}
-	}
-
-	return closestNode
 }
 
 //Returns the contacts in the shortlis that haven't been contacted

--- a/pkg/kademlia/kademlia_test.go
+++ b/pkg/kademlia/kademlia_test.go
@@ -4,28 +4,6 @@ import (
 	"testing"
 )
 
-func TestFindClosestContact(t *testing.T) {
-	//0000000000000000000000000000000000000002
-	//0000000000000000000000000000000000000003 closest
-	//0000000000000000000000000000000000000004
-
-	//0000000000000000000000000000000000000001 TARGET
-	kademliaID1 := NewKademliaID("0000000000000000000000000000000000000001")
-	kademliaID2 := NewKademliaID("0000000000000000000000000000000000000002")
-	kademliaID3 := NewKademliaID("0000000000000000000000000000000000000003")
-	kademliaID4 := NewKademliaID("0000000000000000000000000000000000000004")
-	node1 := NewContact(kademliaID1, "172.16.0.2:8000")
-	node2 := NewContact(kademliaID2, "172.16.0.3:8000")
-	node3 := NewContact(kademliaID3, "172.16.0.4:8000")
-	node4 := NewContact(kademliaID4, "172.16.0.5:8000")
-	contacts := []Contact{node2, node3, node4}
-
-	closestContact := findClosestContact(contacts, &node1)
-	if closestContact.ID != node3.ID {
-		t.Errorf("Contact ID was incorrect, got: %s, want: %s", closestContact.ID.String(), node3.ID.String())
-	}
-}
-
 func TestSendFindNodeRPC(t *testing.T) {
 	network := Network{}
 


### PR DESCRIPTION
**Why this PR is needed**
This PR removed the unecessary function findClosestContact. It was unecessary because there was already a Sort() that could solve that problem. This PR also deletes the unit test for findClosestContact.

**Which issue this PR fixes**
Fixes #48 