### PR TITLE
Add unit tests for preprocessShortlist and preprocessIncomingMessage

### DIFF
--- a/pkg/kademlia/network.go
+++ b/pkg/kademlia/network.go
@@ -144,6 +144,8 @@ func preprocessIncomingMessage(message string) (string, string, string) {
 		if string(letter) == ";" {
 			numberOfEncounteredSemicolon += 1
 			continue
+		} else if string(letter) == "\n" { //All messages end with a newline character
+			break
 		}
 
 		if numberOfEncounteredSemicolon == 0 {

--- a/pkg/kademlia/network.go
+++ b/pkg/kademlia/network.go
@@ -172,6 +172,9 @@ func preprocessShortlist(shortlistString string) []Contact {
 			contactString = contactString + string(letter)
 		}
 	}
+	//Add last contact to shortlist
+	newContact := StringToContact(contactString)
+	shortlist = append(shortlist, newContact)
 	return shortlist
 }
 

--- a/pkg/kademlia/network_test.go
+++ b/pkg/kademlia/network_test.go
@@ -1,6 +1,8 @@
 package kademlia
 
-import "testing"
+import (
+	"testing"
+)
 
 var stringID string = "0000000000000000000000000000000000000001"
 var kademliaID = NewKademliaID(stringID)
@@ -27,5 +29,22 @@ func TestShortlistToString(t *testing.T) {
 	correctFormat := me.String() + ";" + node1.String()
 	if shortlistString != correctFormat {
 		t.Errorf("Convertion to string incorrect, got: %s want: %s", shortlistString, correctFormat)
+	}
+}
+
+func TestPreprocessShortlist(t *testing.T) {
+	contactID := NewKademliaID("0000000000000000000000000000000000000002")
+	contactAddress := "173.16.0.1"
+	node1 := NewContact(contactID, contactAddress)
+	shortlist := []Contact{me, node1}
+	shortlistString := shortlistToString(&shortlist)
+	stringToShortlist := preprocessShortlist(shortlistString)
+	if len(stringToShortlist) != len(shortlist) {
+		t.Errorf("Contact list doesn't have the correct length, got: %d want: %d", len(stringToShortlist), len(shortlist))
+	}
+	for i := 0; i < len(shortlist); i++ {
+		if stringToShortlist[i].ID.String() != shortlist[i].ID.String() || stringToShortlist[i].Address != shortlist[i].Address {
+			t.Errorf("Incorrect conversion from string to shortlist, got: %v want: %v", stringToShortlist, shortlist)
+		}
 	}
 }

--- a/pkg/kademlia/network_test.go
+++ b/pkg/kademlia/network_test.go
@@ -48,3 +48,19 @@ func TestPreprocessShortlist(t *testing.T) {
 		}
 	}
 }
+
+func TestPreprocessIncomingMessage(t *testing.T) {
+	message := "FIND_VALUE_RPC;00001;00002\n"
+	messageType, data, senderIDString := preprocessIncomingMessage(message)
+	if messageType != "FIND_VALUE_RPC" || data != "00001" || senderIDString != "00002" {
+		t.Errorf(
+			"Preprocessing of message is incorrect, got: (message type: %s, data: %s, sender: %s) want: (message type: %s, data: %s, sender: %s)",
+			messageType,
+			data,
+			senderIDString,
+			"FIND_VALUE_RPC",
+			"00001",
+			"00002",
+		)
+	}
+}


### PR DESCRIPTION
**Why this PR is needed**
This PR adds unit tests for `preprocessShortlist()` and `preprocessIncomingMessage()`

**Which issue(s) this PR fixes**
Part of #50