### PR TITLE
Add unit tests for PING and PONG messages

### DIFF
--- a/pkg/kademlia/kademlia.go
+++ b/pkg/kademlia/kademlia.go
@@ -150,7 +150,3 @@ func HashingData(data []byte) *KademliaID {
 
 	return hashedKademliaID
 }
-
-func (kademlia *Kademlia) SendPing() {
-	kademlia.network.SendPingMessage()
-}

--- a/pkg/kademlia/network.go
+++ b/pkg/kademlia/network.go
@@ -77,7 +77,7 @@ func (network *Network) Listen() {
 				go network.routingTable.AddContact(sender)
 			case "PING":
 				network.routingTable.AddContact(sender)
-				sendPongResponse(conn, remoteaddr)
+				network.sendPongResponse(conn, remoteaddr)
 			case "PONG":
 				network.routingTable.AddContact(sender)
 			}
@@ -92,16 +92,16 @@ func (network *Network) SendPingMessage(contact *Contact) {
 		fmt.Printf("Somee error %v", err)
 		return
 	}
-	fmt.Fprintf(conn, "PING;0;"+network.routingTable.me.ID.String()+"\n")
-	if err == nil {
+	_, sendErr := fmt.Fprintf(conn, "PING;0;"+network.routingTable.me.ID.String()+"\n")
+	if sendErr != nil {
 		fmt.Printf("Some error %v\n", err)
 	}
 	conn.Close()
 
 }
 
-func sendPongResponse(conn *net.UDPConn, addr *net.UDPAddr) {
-	_, err := conn.WriteToUDP([]byte("PONG "), addr)
+func (network *Network) sendPongResponse(conn *net.UDPConn, addr *net.UDPAddr) {
+	_, err := conn.WriteToUDP([]byte("PONG;0;"+network.routingTable.me.ID.String()), addr)
 	if err != nil {
 		fmt.Printf("Couldn't send response %v", err)
 	}

--- a/pkg/kademlia/network.go
+++ b/pkg/kademlia/network.go
@@ -86,18 +86,14 @@ func (network *Network) Listen() {
 
 }
 
-func (network *Network) SendPingMessage() {
-	p := make([]byte, 2048)
-	conn, err := net.Dial("udp", "172.18.0.3:8000")
+func (network *Network) SendPingMessage(contact *Contact) {
+	conn, err := net.Dial("udp", contact.Address)
 	if err != nil {
 		fmt.Printf("Somee error %v", err)
 		return
 	}
-	fmt.Fprintf(conn, "PIIING")
-	_, err = bufio.NewReader(conn).Read(p)
+	fmt.Fprintf(conn, "PING;0;"+network.routingTable.me.ID.String()+"\n")
 	if err == nil {
-		fmt.Printf("%s\n", p)
-	} else {
 		fmt.Printf("Some error %v\n", err)
 	}
 	conn.Close()

--- a/pkg/kademlia/network_test.go
+++ b/pkg/kademlia/network_test.go
@@ -1,6 +1,7 @@
 package kademlia
 
 import (
+	"net"
 	"testing"
 )
 
@@ -8,7 +9,7 @@ var stringID string = "0000000000000000000000000000000000000001"
 var kademliaID = NewKademliaID(stringID)
 var me Contact = NewContact(kademliaID, "127.0.0.1:8000")
 
-//var network *Network = NewNetwork(me)
+var network *Network = NewNetwork(me)
 
 func TestStringToContact(t *testing.T) {
 	contactID := "0000000000000000000000000000000000000002"
@@ -62,5 +63,21 @@ func TestPreprocessIncomingMessage(t *testing.T) {
 			"00001",
 			"00002",
 		)
+	}
+}
+
+func TestSendPingMessage(t *testing.T) {
+	p := make([]byte, 2048)
+	addr := net.UDPAddr{
+		Port: 8000,
+		IP:   net.ParseIP(""),
+	}
+	go network.SendPingMessage(&me)
+	conn, _ := net.ListenUDP("udp", &addr)
+	conn.ReadFromUDP(p)
+	incomingMessage := string(p)
+	messageType, _, _ := preprocessIncomingMessage(incomingMessage)
+	if messageType != "PING" {
+		t.Errorf("PING message was not sent")
 	}
 }

--- a/pkg/kademlia/network_test.go
+++ b/pkg/kademlia/network_test.go
@@ -80,4 +80,25 @@ func TestSendPingMessage(t *testing.T) {
 	if messageType != "PING" {
 		t.Errorf("PING message was not sent")
 	}
+	conn.Close()
+}
+
+func TestSendPongResponse(t *testing.T) {
+	p := make([]byte, 2048)
+	addr := net.UDPAddr{
+		Port: 8000,
+		IP:   net.ParseIP(""),
+	}
+	homeAddr := net.UDPAddr{
+		Port: 8000,
+		IP:   net.ParseIP("127.0.0.1"),
+	}
+	conn, _ := net.ListenUDP("udp", &addr)
+	go network.sendPongResponse(conn, &homeAddr)
+	conn.ReadFromUDP(p)
+	messageType, _, _ := preprocessIncomingMessage(string(p))
+	if messageType != "PONG" {
+		t.Errorf("PONG message was not sent")
+	}
+	conn.Close()
 }


### PR DESCRIPTION
**Why this PR is needed**
This PR adds unit tests for `SendPingMessage()` and `SendPongResponse()` and tests some of the functionality for sending messages.

**Which issue(s) this PR fixes**
Part of #50